### PR TITLE
Create initial CI workflow with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+name: Build
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,5 +5,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: ${{ runner.os }}-pods-
       - run: pod install
       - run: open AppRTCMobile.xcworkspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: pod install
+      - run: open AppRTCMobile.xcworkspace

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# AppRTCMobile
+# AppRTCMobile [![Build](https://github.com/crossle/AppRTCMobile/actions/workflows/ci.yml/badge.svg)](https://github.com/crossle/AppRTCMobile/actions/workflows/ci.yml)
+
 use Xcode compile AppRTCMobile
 
 `pod install`


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds AppRTCMobile on pushes and pull requests. See an [example run here](https://github.com/EwoutH/AppRTCMobile/actions).

GitHub Actions can be [enabled here](https://github.com/crossle/AppRTCMobile/actions).